### PR TITLE
fix: remove duplicate doc tags

### DIFF
--- a/doc/blame_line.txt
+++ b/doc/blame_line.txt
@@ -92,7 +92,7 @@ The available configuration options are (shown with default settings): >
 
 <
 ============================================================================================
-HIGHLIGHTS 													*blame_line-usage*
+HIGHLIGHTS 													*blame_line-highlights*
 
 The blame line will be highlighted using the group given as `hl_group` in the setup
 function, or the `BlameLineNvim` group by default if no group was given.
@@ -114,7 +114,7 @@ To change the highlight settings of the group used do: >
 <
 
 ============================================================================================
-COMMANDS 													*blame_line-usage*
+COMMANDS 													*blame_line-commands*
 
 blame_line.nvim only provides three commands, all for enabling/disabling the plugin:
 
@@ -130,7 +130,7 @@ blame_line.nvim only provides three commands, all for enabling/disabling the plu
   or `BlameLineDisable` if it is enabled.
 
 ============================================================================================
-ISSUES 														*blame_line-usage*
+ISSUES 														*blame_line-issues*
 
 Currently, there are no known issues.
 


### PR DESCRIPTION
This resolves doc error `Vim:E154: Duplicate tag "blame_line-usage"`
![dup-usages](https://github.com/braxtons12/blame_line.nvim/assets/52747707/4085dd89-4ab0-426a-957b-5ab009b021fa)
