### PR TITLE
fix: Only query blame information for the current line

### DIFF
--- a/lua/blame_line/init.lua
+++ b/lua/blame_line/init.lua
@@ -414,7 +414,7 @@ blame_line.__detail.get_commit_data = function(file, line_number)
 	local dir_path = vim.fn.shellescape(blame_line.__detail.substitute_path_separator(vim.fn.expand("%:h", nil, nil)))
 	local file_path_escaped = vim.fn.shellescape(file)
 	local command = "git -C " .. dir_path .. " --no-pager blame --line-porcelain -L "
-		.. line_number .. " -- " .. file_path_escaped
+		.. line_number .. "," .. line_number .. " -- " .. file_path_escaped
 	local result = vim.fn.system(command)
 	local lines = blame_line.__detail.split_string(result, "\n")
 


### PR DESCRIPTION
Per the git-blame man page, "`-L <start>` or `-L <start>,` spans from <start> to end of file," which means that we potentially query the blame information for the entire file if we're on line 1. Supplying both a start and end number limits the query to just the current line, which is the intended behavior.